### PR TITLE
Set up tab and select components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,25 +2,57 @@ import React, { useState, useEffect } from 'react';
 import Tabs from './components/Tabs';
 import Select from './components/Select';
 
+// Updated implementation, using 'window.matchMedia()' events
+// Sources:
+//  - https://gomakethings.com/a-better-way-to-test-breakpoints-with-vanilla-javascript/
+//  - https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
+//  - https://medium.com/swlh/using-window-matchmedia-for-media-queries-in-reactjs-97ddc66fca2e
+
 
 const App = () => {
-  const [isMobile, setIsMobile] = useState(window.innerWidth < 650);
-
-  const setViewport = () => {
-    setIsMobile(window.innerWidth < 650);
-  };
-
-  useEffect(() => {
-    window.addEventListener('resize', setViewport);
+  const [isDesktop, setIsDesktop] = useState<{ matches: boolean }>({
+    matches: window.innerWidth > 650 ? true : false,
   });
 
-  const checkViewPort = isMobile ? <Select /> : <Tabs />;
+  useEffect(() => {
+    let mediaQuery = window.matchMedia("(min-width: 650px)");
+    mediaQuery.addListener(setIsDesktop);
 
-    return (
-      <div>
-        {checkViewPort}
-      </div>
-    )
-}
+    return () => mediaQuery.removeListener(setIsDesktop);
+  }, []);
+
+  const displayOptions = isDesktop.matches ? <Tabs /> : <Select />;
+
+  return (
+    <>
+      {displayOptions}
+    </>
+  );
+};
 
 export default App;
+
+// Original implementation, based on using an addEventListener to look for viewport resize events
+// https://github.com/XiaoA/responsive-tab-select-proof-of-concept/commit/0ebcf36c13ef8a2826106f3f953a595056aadc16
+
+// const App = () => {
+//   const [isMobile, setIsMobile] = useState(window.innerWidth < 650);
+
+//   const setViewport = () => {
+//     setIsMobile(window.innerWidth < 650);
+//   };
+
+//   useEffect(() => {
+//     window.addEventListener('resize', setViewport);
+//   });
+
+//   const checkViewPort = isMobile ? <Select /> : <Tabs />;
+
+//     return (
+//       <div>
+//         {checkViewPort}
+//       </div>
+//     )
+// }
+
+// export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,26 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import Tabs from './components/Tabs';
+import Select from './components/Select';
+
 
 const App = () => {
-  return null;
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 650);
+
+  const setViewport = () => {
+    setIsMobile(window.innerWidth < 650);
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', setViewport);
+  });
+
+  const checkViewPort = isMobile ? <Select /> : <Tabs />;
+
+    return (
+      <div>
+        {checkViewPort}
+      </div>
+    )
 }
 
 export default App;

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+//import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+
+export default function BasicSelect() {
+  const [value, setValue] = React.useState("");
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setValue(event.target.value as string);
+  };
+
+  return (
+    <Box sx={{ width: 150 }}>
+      <FormControl fullWidth>
+       
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={value}
+          label={value}
+          onChange={handleChange}
+        >
+          <MenuItem value={0}>Item One</MenuItem>
+          <MenuItem value={1}>Item Two</MenuItem>
+          <MenuItem value={2}>Item Three</MenuItem>
+        </Select>
+      </FormControl>
+    </Box>
+  );
+}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ p: 3 }}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+export default function BasicTabs() {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+          <Tab label="Item One" {...a11yProps(0)} />
+          <Tab label="Item Two" {...a11yProps(1)} />
+          <Tab label="Item Three" {...a11yProps(2)} />
+        </Tabs>
+      </Box>
+      <TabPanel value={value} index={0}>
+        Item One
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        Item Two
+      </TabPanel>
+      <TabPanel value={value} index={2}>
+        Item Three
+      </TabPanel>
+    </Box>
+  );
+}
+
+// import React from 'react';
+// import Tabs from '@mui/material/Tabs';
+// import Tab from '@mui/material/Tab';
+// import Typography from '@mui/material/Typography';
+// import Box from '@mui/material/Box';
+
+// interface TabPanelProps {
+//   children?: React.ReactNode;
+//   index: number;
+//   value: number;
+// }
+
+
+
+// const Tabs = () => {
+//   return null;
+// }
+
+// export default Tabs;


### PR DESCRIPTION
This PR adds the ability to use vanilla JS window functions, with React  `useState()` and `useEffect()` functions to dynamically switch between a tab menu and a dropdown menu.

1. [window.resize()](https://github.com/XiaoA/responsive-tab-select-proof-of-concept/commit/0ebcf36c13ef8a2826106f3f953a595056aadc16). 
2.  [window.matchMedia()](https://github.com/XiaoA/responsive-tab-select-proof-of-concept/commit/1b8c70ece332527978b4b9a1158da8812acb9138)

While both work, #2, `window.matchMedia()`, is preferred, because it relies on a [MediaQueryList](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList), rather than on an eventListener that watches for window resizes. 